### PR TITLE
Does not allow to use eVison logos by licensee

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-MIT License (applies to source code only)
+Source code is licensed under MIT. Logos and other eVision Trademarks remain the property of the eVision. Therefore, in case if the source code is used, all logos of licensor containing therein shall be removed and/or replaced with those of licensee beforehand. 
+
+MIT License 
 
 Copyright (c) 2017 eVision Industry Software - Open Source Software
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT License
+MIT based License
 
 Copyright (c) 2017 eVision Industry Software - Open Source Software
 
@@ -11,6 +11,10 @@ furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
+
+Logos shall remain the property of the licensor. Therefore, in case if the 
+source code is used, all logos of licensor containing therein shall be 
+removed and/or replaced with those of licensee beforehand.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-MIT based License
+MIT License (applies to source code only)
 
 Copyright (c) 2017 eVision Industry Software - Open Source Software
 
@@ -11,10 +11,6 @@ furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
-
-Logos shall remain the property of the licensor. Therefore, in case if the 
-source code is used, all logos of licensor containing therein shall be 
-removed and/or replaced with those of licensee beforehand.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/TRADEMARK LICENSE
+++ b/TRADEMARK LICENSE
@@ -1,0 +1,7 @@
+Trademark assets license
+
+Copyright (c) 2017 eVision Industry Software - Open Source Software
+
+Logos and all eVision trademark assets shall remain the property of the licensor. Therefore, in case if the 
+source code is used, all logos and eVision assets of licensor containing therein shall be 
+removed and/or replaced with those of licensee beforehand.


### PR DESCRIPTION
In out project we have logos and of course we don't want people to reuse our logo.
We this pull request contains adjustments in the license that will not allow to reuse eVision logos.
But it still MIT based license that allow normal open source cooperation.

Text was adjusted by legal department.